### PR TITLE
Bugfixes for reject command

### DIFF
--- a/src/commands/reject.ts
+++ b/src/commands/reject.ts
@@ -17,6 +17,9 @@ module.exports = new Command({
 		const foundSignup = await mongoSignups.findOne({ discordId })
 		if (!foundSignup) throw new ClientError(ia, `Signup for ${discordId} was not found`)
 
+		// Delete signup
+		await mongoSignups.deleteOne({ discordId })
+
 		const member = await ia.guild.members.fetch(foundSignup.discordId)
 
 		// Remove roles
@@ -26,9 +29,6 @@ module.exports = new Command({
 				.filter(r => !rankResolver(r.name.toUpperCase().replace('GAUNTLET ', '')))
 				.map(r => r.id),
 		)
-
-		// Delete signup
-		await mongoSignups.deleteOne({ discordId })
 
 		// Delete message
 		await signupChannel.messages.fetch(foundSignup.signupMsgId)


### PR DESCRIPTION
Currently the signup can only be deleted when the corresponding member is still on the server. If this is not the case the bot fails before the signup gets deleted. This PR fixes this by removing the signup before the member lookup. We can also use this PR to rename the command and make it more robust with more commits